### PR TITLE
tweak: Make SpawnStackingComponent not required on client again

### DIFF
--- a/src/main/java/pepjebs/bunkbeds/SpawnStackingComponent.java
+++ b/src/main/java/pepjebs/bunkbeds/SpawnStackingComponent.java
@@ -20,6 +20,11 @@ public class SpawnStackingComponent implements AutoSyncedComponent, ComponentV3,
     private static final HashMap<String, List<BlockPos>> bedSpawns = new HashMap<>();
 
     @Override
+    public boolean isRequiredOnClient() {
+        return false;
+    }
+
+    @Override
     public void readData(ReadView readView) {
         int size = readView.getInt("size", 0);
         for (int i = 0; i < size; i++) {


### PR DESCRIPTION
As shown [here](https://ladysnake.org/wiki/cardinal-components-api/upgrade-instructions/CCA-6-changes#client-optional-components), in Cardinal Components API 6 components are now required client side by default.

To restore the old behavior you can override the `isRequiredOnClient()` method on your component which will prevent kicking the player if they do not have the mod.